### PR TITLE
Support `false` mappings in `"browser"` fields

### DIFF
--- a/packager/react-packager/src/node-haste/DependencyGraph/ResolutionRequest.js
+++ b/packager/react-packager/src/node-haste/DependencyGraph/ResolutionRequest.js
@@ -17,6 +17,8 @@ const realPath = require('path');
 const isAbsolutePath = require('absolute-path');
 const getAssetDataFromName = require('../lib/getAssetDataFromName');
 
+const emptyModule = require.resolve('./assets/empty-module.js');
+
 class ResolutionRequest {
   constructor({
     platform,
@@ -193,7 +195,7 @@ class ResolutionRequest {
 
         if (recursive) {
           // doesn't block the return of this function invocation, but defers
-          // the resulution of collectionsInProgress.done.then(…)
+          // the resolution of collectionsInProgress.done.then(...)
           dependencyModules
             .forEach(dependency => collectedDependencies.get(dependency));
         }
@@ -322,7 +324,7 @@ class ResolutionRequest {
     return this._redirectRequire(fromModule, potentialModulePath).then(
       realModuleName => {
         if (realModuleName === false) {
-          return null;
+          return this._loadAsFile(emptyModule, fromModule, toModuleName);
         }
 
         return this._tryResolve(
@@ -341,7 +343,7 @@ class ResolutionRequest {
         realModuleName => {
           // exclude
           if (realModuleName === false) {
-            return null;
+            return this._loadAsFile(emptyModule, fromModule, toModuleName);
           }
 
           if (isRelativeImport(realModuleName) || isAbsolutePath(realModuleName)) {

--- a/packager/react-packager/src/node-haste/DependencyGraph/assets/empty-module.js
+++ b/packager/react-packager/src/node-haste/DependencyGraph/assets/empty-module.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */


### PR DESCRIPTION
Enables us to use react-intl. This patch is already included in RN 0.35+ so we might want to ignore this pull-request and patch the latest version instead.

found here: https://github.com/yahoo/react-intl/issues/620#issuecomment-247600683
Cherry-picked from: https://github.com/facebook/react-native/commit/5710b230a2a0f2b29553fbf94af5147a2e030f44